### PR TITLE
Fix timeout test for new Polars exception

### DIFF
--- a/test_polars_requests.py
+++ b/test_polars_requests.py
@@ -2,11 +2,11 @@ from typing import Any
 
 import polars as pl
 import pytest
+import requests
 from hypothesis import given
 from hypothesis import strategies as st
 from hypothesis.provisional import urls
 from hypothesis.strategies import DrawFn, composite
-from polars.exceptions import ComputeError
 from polars.testing import assert_frame_equal
 from polars.testing.parametric import series
 
@@ -314,7 +314,7 @@ def test_request_timeout() -> None:
         }
     )
 
-    with pytest.raises(ComputeError):
+    with pytest.raises(requests.exceptions.Timeout):
         ldf.collect()
 
 


### PR DESCRIPTION
## Summary
- adapt `test_request_timeout` to the new Polars behavior preserving the original `requests` exception

## Testing
- `pytest test_polars_requests.py::test_request_timeout -q`


------
https://chatgpt.com/codex/tasks/task_e_685af9f18af08326883b531b41ab273d