### PR TITLE
Remove deprecated physical categorical ordering

### DIFF
--- a/opencritic_etl.py
+++ b/opencritic_etl.py
@@ -51,7 +51,7 @@ _OPENCRITIC_GAME_DTYPE = pl.Struct(
     {
         "name": pl.Utf8(),
         "url": pl.Utf8(),
-        "tier": pl.Categorical(ordering="physical"),
+        "tier": pl.Categorical(),
         "percent_recommended": pl.Float32(),
         "num_reviews": pl.UInt16(),
         "num_top_critic_reviews": pl.UInt16(),

--- a/test_polars_utils.py
+++ b/test_polars_utils.py
@@ -96,7 +96,7 @@ def test_merge_with_indicator() -> None:
             "a": pl.Int64(),
             "b": pl.Int64(),
             "b_right": pl.Int64(),
-            "_merge": pl.Categorical(ordering="physical"),
+            "_merge": pl.Categorical(),
         },
     )
     assert_frame_equal(df3, df4)


### PR DESCRIPTION
## Summary
- drop deprecated `ordering="physical"` from categorical schemas

## Testing
- `uv run ruff format --diff .`
- `uv run ruff check .`
- `uv tool run ssort .`
- `uv run mypy .`
- `uv run pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bf082c53688326a22db69dc4e3dadb