### PR TITLE
Handle invalid IMDb numeric conversions

### DIFF
--- a/wd_tmdb.py
+++ b/wd_tmdb.py
@@ -20,7 +20,7 @@ _IMDB_ID_PATTERN: dict[TMDB_TYPE, str] = {
 def _extract_imdb_numeric_id(expr: pl.Expr, tmdb_type: TMDB_TYPE) -> pl.Expr:
     return (
         expr.str.extract(_IMDB_ID_PATTERN[tmdb_type], 1)
-        .cast(pl.UInt32)
+        .cast(pl.UInt32, strict=False)
         .alias("imdb_numeric_id")
     )
 


### PR DESCRIPTION
## Summary
- allow IMDb numeric ID extraction to tolerate values that cannot fit into a 32-bit integer

## Testing
- uv run pytest test_wd_tmdb.py

------
https://chatgpt.com/codex/tasks/task_e_68efc37e83d08326a3f685a41cd20e0a