### PR TITLE
Use ubuntu-slim only for lint and merge workflows

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,7 +4,7 @@ on: push
 
 jobs:
   ruff:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-slim
 
     env:
       RUFF_OUTPUT_FORMAT: github
@@ -24,7 +24,7 @@ jobs:
         run: uv run ruff check .
 
   mypy:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-slim
 
     strategy:
       matrix:

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -8,7 +8,7 @@ permissions:
 
 jobs:
   merge:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-slim
     if: github.actor == 'dependabot[bot]' && github.repository == 'josh/wikidatabots'
 
     steps:


### PR DESCRIPTION
## Summary
- revert non-lint GitHub Actions workflows to ubuntu-24.04 runners
- keep lint and merge workflows on the container-based ubuntu-slim runner

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69236fa9319483269e480a645cc5a946)