### PR TITLE
Add dependabot cooldown period

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 14
     open-pull-requests-limit: 10
     ignore:
       - dependency-name: "types-*"
@@ -17,3 +19,5 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 14


### PR DESCRIPTION
## Summary
- add a 14-day cooldown to Dependabot updates for uv dependencies and GitHub Actions while keeping weekly schedule

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6924ae502198832695bd4b4c9712c097)